### PR TITLE
Add missing StreamingResponse import

### DIFF
--- a/fastapi_app/main.py
+++ b/fastapi_app/main.py
@@ -3,6 +3,7 @@
 # TODO: add rate limiting
 import os, time
 from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from .retriever import retrieve
 from .llm_loader import stream
 from clickhouse_connect import get_client


### PR DESCRIPTION
## Summary
- import `StreamingResponse` in `fastapi_app.main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6846dd50f5288329856b6a6d6786d704