### PR TITLE
Fix dependency quoting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ transformers = "^4.33"
 bitsandbytes = "^0.41"
 clickhouse-connect = "^0.6"
 pydantic = "^2.4"
-pdfminer.six = "^20221105"
+"pdfminer.six" = "^20221105"
 python-docx = "^0.8"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- quote `pdfminer.six` dependency in `pyproject.toml`

## Testing
- `poetry check`

------
https://chatgpt.com/codex/tasks/task_e_6846dd3a60f08329bbe8603d65e080bb