### PR TITLE
Add httpx dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ transformers = "^4.33"
 bitsandbytes = "^0.41"
 clickhouse-connect = "^0.6"
 pydantic = "^2.4"
-pdfminer.six = "^20221105"
+"pdfminer.six" = "^20221105"
 python-docx = "^0.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"
+httpx = "^0.26"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- fix quoting for `pdfminer.six` dependency in `pyproject.toml`
- add `httpx` as dev dependency

## Testing
- `poetry check`
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6846dd2b1d9c8329a695cbadb02ca316