### PR TITLE
Fix pyproject key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ transformers = "^4.33"
 bitsandbytes = "^0.41"
 clickhouse-connect = "^0.6"
 pydantic = "^2.4"
-pdfminer.six = "^20221105"
+"pdfminer.six" = "^20221105"
 python-docx = "^0.8"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- fix quoting in pyproject for pdfminer.six

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_e_6846e2e6260c8329ac8891aba15e87f6